### PR TITLE
Train turkish bert model for support classification

### DIFF
--- a/TalepMerkezi/Program.cs
+++ b/TalepMerkezi/Program.cs
@@ -14,6 +14,12 @@ builder.Services.AddDbContext<AppDbContext>(opt =>
 // === AI Servisi ===
 // Development: Hata fırlatsın, debug kolay olsun.
 // Production: Daha toleranslı olsun, boş sonuç dönsün.
+// HttpClientFactory (hem Dev hem Prod için hazır olsun)
+builder.Services.AddHttpClient("ai", c =>
+{
+    c.Timeout = TimeSpan.FromSeconds(15);
+});
+
 if (builder.Environment.IsDevelopment())
 {
     builder.Services.AddScoped<IAIClassifier, AiClassifier>();

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -52,6 +52,12 @@ def _startup():
     except Exception as e:
         # Model yüklenemezse servis yine çalışır; /classify-ml kurala düşer.
         print(f"[AI] ML model load FAILED: {e}")
+    # İkinci model (support2)
+    try:
+        ml_manager_support2.load()
+        print("[AI] Support2 model loaded successfully.")
+    except Exception as e:
+        print(f"[AI] Support2 model load FAILED: {e}")
 
 
 # ==== Yardımcılar (senin kural fonksiyonların) ====


### PR DESCRIPTION
Enable loading a local BERT model for the `/classify-support2` endpoint.

This allows the service to run with a user-trained model stored locally by updating the model path resolution and adding a startup load for the second model manager. The `bert_classifier.py` now handles relative paths and auto-detects the model subfolder if a parent directory is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8e1ee89-721d-493c-8dd4-86af0cd89441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8e1ee89-721d-493c-8dd4-86af0cd89441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

